### PR TITLE
chore(workerd): bump capnp-parse version

### DIFF
--- a/.github/workflows/mine-workerd.yml
+++ b/.github/workflows/mine-workerd.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           mkdir -p temp
           cd temp
-          curl -L -O https://github.com/KianNH/capnp-parse/releases/download/0.0.2/capnp-parse-x86_64-unknown-linux-gnu.tar.gz
+          curl -L -O https://github.com/KianNH/capnp-parse/releases/download/0.0.3/capnp-parse-x86_64-unknown-linux-gnu.tar.gz
           tar zxf capnp-parse-x86_64-unknown-linux-gnu.tar.gz
           git clone --depth 1 https://github.com/cloudflare/workerd.git
           ./capnp-parse -g "./workerd/**/*.capnp" -e "config.capnp" -e "worker-interface.capnp" -e "workerd.capnp" -e "icudata-embed.capnp" -o "workerd-output.json"


### PR DESCRIPTION
`0.0.3` introduces names to the annotations