### PR TITLE
[turnstile] fix widget url

### DIFF
--- a/scripts/src/products/turnstile.js
+++ b/scripts/src/products/turnstile.js
@@ -106,11 +106,11 @@ for(const js of javascripts){
 const htmlCssUrls = [
 	{
 		name: 'staging',
-		url: `https://challenges-staging.cloudflare.com/cdn-cgi/challenge-platform/turnstile/if/ov2/av0/00000/${results['widgets-list'].result[0].sitekey}/auto`,
+		url: `https://challenges-staging.cloudflare.com/cdn-cgi/challenge-platform/turnstile/if/ov2/av0/00000/${results['widgets-list'].result[0].sitekey}/auto/normal`,
 	},
 	{
 		name: 'prod',
-		url: `https://challenges.cloudflare.com/cdn-cgi/challenge-platform/turnstile/if/ov2/av0/00000/${results['widgets-list'].result[0].sitekey}/auto`,
+		url: `https://challenges.cloudflare.com/cdn-cgi/challenge-platform/turnstile/if/ov2/av0/00000/${results['widgets-list'].result[0].sitekey}/auto/normal`,
 	},
 ];
 for(const htmlCss of htmlCssUrls){


### PR DESCRIPTION
This is currently causing a 400: Invalid Request error.
This should only be merged after the size is added to the end of the url.