### PR TITLE
Update turnstile mining

### DIFF
--- a/scripts/src/products/turnstile.js
+++ b/scripts/src/products/turnstile.js
@@ -106,11 +106,11 @@ for (const js of javascripts) {
 const htmlCssUrls = [
 	{
 		name: 'normal',
-		url: `https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/av0/00000/${results['widgets-list'].result[0].sitekey}/auto/normal`,
+		url: `https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/av0/00000/${results['widgets-list'].result[0].sitekey}/auto/fbE/new/normal/auto/`,
 	},
 	{
 		name: 'compact',
-		url: `https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/av0/00000/${results['widgets-list'].result[0].sitekey}/auto/compact`,
+		url: `https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/av0/00000/${results['widgets-list'].result[0].sitekey}/auto/fbE/new/compact/auto/`,
 	},
 ];
 for (const htmlCss of htmlCssUrls) {
@@ -149,6 +149,6 @@ await tryAndPush(
 	],
 	`${prefix} - Product: Turnstile Data was updated! [skip ci]`,
 	'CFData - Product: Turnstile Data Update',
-	'Pushed Product: Turnstile Data: ' + prefix + ' (<@922118393178517545>)',
+	'Pushed Product: Turnstile Data: ' + prefix,
 	'DISCORD_WEBHOOK_PRODUCT_TURNSTILE',
 );


### PR DESCRIPTION
- removed my ping
- fixed the path for widgets, so HTML/CSS mining should be back

--- Copilot summary for luls ---

This pull request includes updates to the `scripts/src/products/turnstile.js` file. The changes involve modifying URL paths and updating a message format.

Key changes:

* Updated URL paths for 'normal' and 'compact' configurations to include new segments (`auto/fbE/new/`) in the `htmlCssUrls` array.
* Removed a user mention from the push notification message in the `tryAndPush` function.